### PR TITLE
Merge together multiple swagger_components

### DIFF
--- a/lib/swagger/blocks/class_methods.rb
+++ b/lib/swagger/blocks/class_methods.rb
@@ -54,7 +54,11 @@ module Swagger
       end
 
       def swagger_component(inline_keys = nil, &block)
-        @swagger_components_node ||= Swagger::Blocks::Nodes::ComponentNode.call(version: '3.0.0', inline_keys: inline_keys, &block)
+        if @swagger_components_node
+          @swagger_components_node.instance_eval(&block)
+        else
+          @swagger_components_node = Swagger::Blocks::Nodes::ComponentNode.call(version: '3.0.0', inline_keys: inline_keys, &block)
+        end
       end
 
       def _swagger_nodes

--- a/lib/swagger/blocks/nodes/items_node.rb
+++ b/lib/swagger/blocks/nodes/items_node.rb
@@ -12,6 +12,11 @@ module Swagger
         def items(inline_keys = nil, &block)
           self.data[:items] = Swagger::Blocks::Nodes::ItemsNode.call(version: version, inline_keys: inline_keys, &block)
         end
+        
+        def one_of(&block)
+          self.data[:oneOf] ||= []
+          self.data[:oneOf] << Swagger::Blocks::Nodes::OneOfNode.call(version: version, &block)
+        end
       end
     end
   end


### PR DESCRIPTION
In our app, we have an object with a DSL that represents how objects will be serialized to JSON. I was trying to add swagger schemas within swagger components to these instances and found that only the first one was showing up.

Thanks for the 3.0 updates :)